### PR TITLE
Sync wip with master

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CopernicusMarine
 Type: Package
 Title: Search Download and Handle Data from Copernicus Marine Service Information
-Version: 0.3.5.0001
+Version: 0.3.5.0002
 Authors@R: c(person("Pepijn", "de Vries", role = c("aut", "cre", "dtc"),
     email = "pepijn.devries@outlook.com",
     comment = c(ORCID = "0000-0002-7961-6646")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-CopernicusMarine v0.3.5.0001
+CopernicusMarine v0.3.5.0002
 -------------
 
  * Updated documentation

--- a/R/cms_download_subset.r
+++ b/R/cms_download_subset.r
@@ -5,9 +5,6 @@
 #'
 #' @include cms_login.r
 #' @inheritParams cms_login
-#' @param destination `r lifecycle::badge("deprecated")` This argument is deprecated.
-#' Data is no longer written to a file but loaded as a [stars::st_as_stars()] object
-#' into memory.
 #' @param product An identifier (type `character`) of the desired Copernicus marine product.
 #' Can be obtained with [`cms_products_list`].
 #' @param layer The name of a desired layer within a product (type `character`). Can be obtained with [`cms_product_services`] (listed as `id` column).
@@ -20,9 +17,6 @@
 #' @param verticalrange A `vector` with two elements (minimum and maximum)
 #' numerical values for the depth of the vertical layers (if any). Note that values below the
 #' sea surface needs to be specified as negative values.
-#' @param overwrite `r lifecycle::badge("deprecated")` This argument is deprecated.
-#' Data is no longer written to a file but loaded as a [stars::st_as_stars()] object
-#' into memory.
 #' @param progress A logical value. When `TRUE` (default) progress is reported to the console.
 #' Otherwise, this function will silently proceed.
 #' @param crop On the server, the data is organised in chunks. The subset
@@ -60,14 +54,12 @@
 cms_download_subset <- function(
     username = cms_get_username(),
     password = cms_get_password(),
-    destination,
     product,
     layer,
     variable,
     region,
     timerange,
     verticalrange,
-    overwrite = FALSE,
     progress = TRUE,
     crop = TRUE,
     asset,

--- a/R/cms_login.r
+++ b/R/cms_login.r
@@ -61,7 +61,7 @@ cms_login <- function(
 
 #' Set or get Copernicus account details
 #' 
-#' Set or get username and password throughout an R session.
+#' `r lifecycle::badge('stable')` Set or get username and password throughout an R session.
 #' This can be used to obscure your account details in an R script and
 #' store them as either an R option or system environment variable.
 #' @param username Your Copernicus Marine username
@@ -122,4 +122,3 @@ cms_set_password <- function(password, method = c("option", "sysenv")) {
     })
   return(invisible())
 }
-

--- a/man/account.Rd
+++ b/man/account.Rd
@@ -28,7 +28,7 @@ Returns your account details for the \code{get} variant or nothing in case
 of the \code{set} variant.
 }
 \description{
-Set or get username and password throughout an R session.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}} Set or get username and password throughout an R session.
 This can be used to obscure your account details in an R script and
 store them as either an R option or system environment variable.
 }

--- a/man/cms_download_subset.Rd
+++ b/man/cms_download_subset.Rd
@@ -7,14 +7,12 @@
 cms_download_subset(
   username = cms_get_username(),
   password = cms_get_password(),
-  destination,
   product,
   layer,
   variable,
   region,
   timerange,
   verticalrange,
-  overwrite = FALSE,
   progress = TRUE,
   crop = TRUE,
   asset,
@@ -27,10 +25,6 @@ cms_download_subset(
 
 \item{password}{Your Copernicus marine password. Can be provided as
 \code{cms_get_password()} (default), or as argument here.}
-
-\item{destination}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is deprecated.
-Data is no longer written to a file but loaded as a \code{\link[stars:st_as_stars]{stars::st_as_stars()}} object
-into memory.}
 
 \item{product}{An identifier (type \code{character}) of the desired Copernicus marine product.
 Can be obtained with \code{\link{cms_products_list}}.}
@@ -49,10 +43,6 @@ for a requested time range. The \code{vector} should be coercible to \code{POSIX
 \item{verticalrange}{A \code{vector} with two elements (minimum and maximum)
 numerical values for the depth of the vertical layers (if any). Note that values below the
 sea surface needs to be specified as negative values.}
-
-\item{overwrite}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is deprecated.
-Data is no longer written to a file but loaded as a \code{\link[stars:st_as_stars]{stars::st_as_stars()}} object
-into memory.}
 
 \item{progress}{A logical value. When \code{TRUE} (default) progress is reported to the console.
 Otherwise, this function will silently proceed.}


### PR DESCRIPTION
* blosc from 'imports' to 'suggests'. Added support for omi and downsample4 assets

* correction in setting time dimension

* completed documentation

* Fix in asset checks

* Fix for empty/missing chunks

* Update version

* Improved dimension handling in subsetter

* Fixed bug in assigning temporal dimension

* version bump

* Fix in dimensioning of zarr data

* Updated README

* added screen capture

* Added `cms_translate()`

* version bump

* minor updates

* increase fig size in vignette

* corrected typo

* Fix for https://github.com/pepijn-devries/CopernicusMarine/issues/100

* Version bump for CRAN release

* Fix for https://github.com/pepijn-devries/CopernicusMarine/issues/102

* Updated NEWS

* Version bump for CRAN release

* Updated URL in README

* Updated documentation in response of https://github.com/pepijn-devries/CopernicusMarine/issues/106

* Added lifecycle badge to login functions. Removed deprecated arguments to `cms_download_subset()`