### PR TITLE
docs: update EMODnet R tutorials URL after repo transfer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CopernicusMarine
 Type: Package
 Title: Search Download and Handle Data from Copernicus Marine Service Information
-Version: 0.4.6.0001
+Version: 0.4.6.0002
 Authors@R: c(person("Pepijn", "de Vries", role = c("aut", "cre", "dtc"),
     email = "pepijn.devries@outlook.com",
     comment = c(ORCID = "0000-0002-7961-6646")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-CopernicusMarine v0.4.6.0001
+CopernicusMarine v0.4.6.0002
 -------------
 
  * Fixed tests
+ * Updated documentation
 
 CopernicusMarine v0.4.6
 -------------

--- a/README.Rmd
+++ b/README.Rmd
@@ -72,7 +72,7 @@ Please check the manual for complete documentation of the package.
 
 For an excellent tutorial showing how to combine multiple spatial datasets
 from different sources (amongst which is CopernicusMarine), check out:
-[EMODnet Biology Geospatial R Tutorials (Tutorial 4)](https://r-rse.github.io/emodnet-bio-r-geo-tutorials/tutorials/tutorial-04.html)
+[EMODnet Biology Geospatial R Tutorials (Tutorial 4)](https://emodnet.github.io/emodnet-bio-r-geo-tutorials/tutorials/tutorial-04.html)
 by [Anna Krystalli](https://github.com/annakrystalli)
 
 <h3 id="sec-subset">Downloading a subset</h3>

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ complete documentation of the package.
 For an excellent tutorial showing how to combine multiple spatial
 datasets from different sources (amongst which is CopernicusMarine),
 check out: [EMODnet Biology Geospatial R Tutorials (Tutorial
-4)](https://r-rse.github.io/emodnet-bio-r-geo-tutorials/tutorials/tutorial-04.html)
+4)](https://emodnet.github.io/emodnet-bio-r-geo-tutorials/tutorials/tutorial-04.html)
 by [Anna Krystalli](https://github.com/annakrystalli)
 
 <h3 id="sec-subset">

--- a/vignettes/glossary.Rmd
+++ b/vignettes/glossary.Rmd
@@ -24,7 +24,7 @@ so you don't have to know all technical aspects.
 
 However, since jargon can vary among data portals, I've put together
 a glossary of terms used by Copernicus Marine. It is based on the
-excellent [tutorial](https://r-rse.github.io/emodnet-bio-r-geo-tutorials/tutorials/tutorial-04.html)
+excellent [tutorial](https://emodnet.github.io/emodnet-bio-r-geo-tutorials/tutorials/tutorial-04.html)
 by [Anna Krystalli](https://github.com/annakrystalli). This
 tutorial also highlights some contrasts with other data portals.
 The table below lists some important definitions and their background.


### PR DESCRIPTION
The EMODnet Biology Geospatial R Tutorials referenced from your README and the glossary vignette were transferred from `r-rse/` to the `EMODnet/` GitHub org earlier today. The rendered site is now at `https://emodnet.github.io/emodnet-bio-r-geo-tutorials/`.

Updates the three references:

- `README.Rmd` L75
- `README.md` L75 (kept in sync with the .Rmd)
- `vignettes/glossary.Rmd` L27

Thanks for the kind shout-out!